### PR TITLE
Implement audit and task model updates

### DIFF
--- a/common.go
+++ b/common.go
@@ -11,15 +11,19 @@ import (
 type Status string
 
 const (
-	StatusPending    Status = "pending"
-	StatusInProgress Status = "in_progress"
-	StatusFailed     Status = "failed"
-	StatusComplete   Status = "complete"
+	StatusPending        Status = "pending"
+	StatusInProgress     Status = "in_progress"
+	StatusSucceeded      Status = "succeeded"
+	StatusFailed         Status = "failed"
+	StatusPendingCancel  Status = "pending_cancellation"
+	StatusCancelled      Status = "cancelled"
+	StatusFailedToCancel Status = "failed_to_cancel"
 )
 
 func (s Status) IsValid() bool {
 	switch s {
-	case StatusPending, StatusInProgress, StatusFailed, StatusComplete:
+	case StatusPending, StatusInProgress, StatusSucceeded, StatusFailed,
+		StatusPendingCancel, StatusCancelled, StatusFailedToCancel:
 		return true
 	}
 	return false

--- a/model/models.go
+++ b/model/models.go
@@ -7,16 +7,44 @@ import (
 	"gorm.io/gorm"
 )
 
+type AuditModel struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+	CreatedBy *string        `gorm:"type:varchar(254);index"`
+	UpdatedBy *string        `gorm:"type:varchar(254);index"`
+	DeletedBy *string        `gorm:"type:varchar(254);index"`
+}
+
 // ============================
 // Task Models
 // ============================
 type Task struct {
-	gorm.Model
-	Type        string `gorm:"index;not null"`
-	Status      string `gorm:"index;default:'pending'"`
-	RequestorID string `gorm:"type:varchar(320);index;not null"`
-	WorkerIdent string `gorm:"type:varchar(255)"`
-	Result      string `gorm:"type:text"`
+	ID            uuid.UUID  `gorm:"type:uuid;primaryKey"`
+	FriendlyID    uint       `gorm:"autoIncrement;not null"`
+	Type          string     `gorm:"index;not null"`
+	ReferenceID   string     `gorm:"index"`
+	Status        string     `gorm:"index;default:'pending'"`
+	Payload       string     `gorm:"type:text"`
+	Result        string     `gorm:"type:text"`
+	ParentTaskID  *uuid.UUID `gorm:"type:uuid"`
+	Attempt       int
+	StartedAt     *time.Time
+	ItemsTotal    int
+	ItemsImpacted int
+	ItemsFailed   int
+	AuditModel
+}
+
+func (t *Task) BeforeCreate(tx *gorm.DB) error {
+	if t.ID == uuid.Nil {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return err
+		}
+		t.ID = id
+	}
+	return nil
 }
 
 type TaskInput struct {


### PR DESCRIPTION
## Summary
- add new status constants
- overhaul task model with UUID primary keys and audit fields
- add before create hook to generate v7 UUIDs
- extend manager with cancellation, retry, and list helpers

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6870ecd067748323abf4949b30be08f8