### PR TITLE
Refactor handlers to use Manager

### DIFF
--- a/cmd/taskforge/main.go
+++ b/cmd/taskforge/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/agincgit/taskforge"
 	"github.com/agincgit/taskforge/config"
+	"github.com/agincgit/taskforge/server"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	// 4) Create TaskForge router (with migrations & handlers)
-	router, err := taskforge.NewRouter(db)
+	router, err := server.NewRouter(db)
 	if err != nil {
 		log.Fatalf("Failed to initialize TaskForge: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1,25 +1,31 @@
-package taskforge
+package server
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	taskforge "github.com/agincgit/taskforge"
 	"github.com/agincgit/taskforge/handler"
 )
 
 // NewRouter sets up database migrations and registers all TaskForge API routes.
 func NewRouter(db *gorm.DB) (*gin.Engine, error) {
-	_, err := DBMigrate(db)
+	mgr, err := taskforge.NewManager(taskforge.TaskForgeConfig{
+		DB:        db,
+		TableName: "tasks",
+		Context:   context.Background(),
+	})
 	if err != nil {
-		fmt.Println("Database changes failed to apply")
+		return nil, err
 	}
+
 	router := gin.Default()
 	api := router.Group("/taskforge/api/v1")
 
 	// Task endpoints
-	th := handler.NewTaskHandler(db)
+	th := handler.NewTaskHandler(mgr)
 	api.POST("/tasks", th.CreateTask)
 	api.GET("/tasks", th.GetTasks)
 	api.PUT("/tasks/:id", th.UpdateTask)


### PR DESCRIPTION
## Summary
- implement CRUD helper methods in `manager.go`
- store `TaskForgeConfig` in `Manager` and validate DB in constructor
- refactor `TaskHandler` to use `Manager`
- move router to dedicated `server` package and use manager
- update `main.go` to import new server package

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878572f85b08323ab0623973de47182